### PR TITLE
Filter recommendations by location and availability

### DIFF
--- a/api/src/index.test.ts
+++ b/api/src/index.test.ts
@@ -92,7 +92,13 @@ describe("DocSeek API", () => {
 		const app = createApp({
 			searchService: async ({ symptoms, options }) => {
 				expect(symptoms).toBe("persistent headaches and migraines");
-				expect(options).toEqual({ limit: 5 });
+				expect(options).toEqual({
+					limit: 5,
+					filters: {
+						location: null,
+						onlyAcceptingNewPatients: undefined,
+					},
+				});
 				return [doctor];
 			},
 		});
@@ -113,6 +119,52 @@ describe("DocSeek API", () => {
 		expect(body).toEqual({
 			doctors: [doctor],
 		});
+	});
+
+	test("passes filter parameters to the search service", async () => {
+		const doctor = {
+			id: 2,
+			source_provider_id: 1002,
+			npi: null,
+			full_name: "Dr. John Smith",
+			first_name: "John",
+			middle_name: null,
+			last_name: "Smith",
+			suffix: null,
+			primary_specialty: "Cardiology",
+			accepting_new_patients: true,
+			profile_url: null,
+			ratings_url: null,
+			book_appointment_url: null,
+			primary_location: "Monroeville, PA",
+			primary_phone: null,
+			created_at: "2026-03-23T00:00:00.000Z",
+		};
+
+		const app = createApp({
+			searchService: async ({ symptoms, options }) => {
+				expect(symptoms).toBe("chest pain");
+				expect(options?.filters?.location).toBe("Pittsburgh");
+				expect(options?.filters?.onlyAcceptingNewPatients).toBe(true);
+				return [doctor];
+			},
+		});
+
+		const response = await app.request("http://localhost/doctors/search", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				symptoms: "chest pain",
+				location: "Pittsburgh",
+				onlyAcceptingNewPatients: true,
+			}),
+		});
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.doctors).toHaveLength(1);
 	});
 
 	test("returns a bad request for an invalid limit", async () => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -34,6 +34,12 @@ export function createApp({
 		const body = await c.req.json().catch(() => null);
 		const symptoms = typeof body?.symptoms === "string" ? body.symptoms.trim() : "";
 		const limit = body?.limit;
+		const location =
+			typeof body?.location === "string" ? body.location.trim() || undefined : undefined;
+		const onlyAcceptingNewPatients =
+			typeof body?.onlyAcceptingNewPatients === "boolean"
+				? body.onlyAcceptingNewPatients
+				: undefined;
 
 		if (!symptoms) {
 			return c.json(
@@ -53,6 +59,10 @@ export function createApp({
 				symptoms,
 				options: {
 					limit,
+					filters: {
+						location: location ?? null,
+						onlyAcceptingNewPatients,
+					},
 				},
 			});
 

--- a/api/src/search.ts
+++ b/api/src/search.ts
@@ -26,8 +26,14 @@ type EmbeddingsResponse = {
 	}>;
 };
 
+export type SearchFilters = {
+	location?: string | null;
+	onlyAcceptingNewPatients?: boolean;
+};
+
 type SearchDoctorsOptions = {
 	limit?: number;
+	filters?: SearchFilters;
 };
 
 type SearchDoctorsParams = {
@@ -97,6 +103,14 @@ export function createDoctorSearchService(
 
 	return async ({ symptoms, options }) => {
 		const limit = normalizeSearchLimit(options?.limit);
+		const filters = options?.filters ?? {};
+		const locationFilter =
+			typeof filters.location === "string" && filters.location.trim()
+				? filters.location.trim()
+				: null;
+		const onlyAccepting =
+			filters.onlyAcceptingNewPatients === true ? true : null;
+
 		const embedding = await requestEmbedding(symptoms, config);
 		const vectorLiteral = formatVectorLiteral(embedding);
 
@@ -105,6 +119,8 @@ export function createDoctorSearchService(
 			FROM doctor_search_embeddings dse
 			INNER JOIN doctors d ON d.id = dse.doctor_id
 			WHERE dse.embedding IS NOT NULL
+			AND (${locationFilter}::text IS NULL OR d.primary_location ILIKE '%' || ${locationFilter} || '%')
+			AND (${onlyAccepting}::boolean IS NULL OR d.accepting_new_patients = true)
 			ORDER BY dse.embedding <=> ${vectorLiteral}::vector
 			LIMIT ${limit}
 		`;

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -1,5 +1,11 @@
-import { Link } from "@tanstack/react-router";
-import { ArrowLeft, ArrowRight, Search, Stethoscope } from "lucide-react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import {
+	ArrowLeft,
+	ArrowRight,
+	Filter,
+	Search,
+	Stethoscope,
+} from "lucide-react";
 import { type FormEvent, type ReactNode, useEffect, useState } from "react";
 
 const API_BASE_URL =
@@ -26,9 +32,22 @@ type DoctorSearchResponse = {
 	doctors: Doctor[];
 };
 
+export type SearchFilters = {
+	location?: string;
+	onlyAcceptingNewPatients?: boolean;
+};
+
 type SearchDoctorsOptions = {
 	apiBaseUrl?: string;
 	fetchImpl?: typeof fetch;
+	filters?: SearchFilters;
+};
+
+type SearchFiltersFormProps = {
+	location: string;
+	onlyAcceptingNewPatients: boolean;
+	onLocationChange: (value: string) => void;
+	onOnlyAcceptingChange: (value: boolean) => void;
 };
 
 type SearchPageShellProps = {
@@ -44,10 +63,11 @@ type SearchFormProps = {
 
 type SearchHeroProps = SearchFormProps & {
 	errorMessage?: string;
+	filters?: SearchFiltersFormProps;
 };
 
 type HomePageProps = {
-	navigateToResults: (symptoms: string) => void;
+	navigateToResults: (symptoms: string, filters?: SearchFilters) => void;
 };
 
 type DoctorRecommendationCardProps = {
@@ -59,14 +79,32 @@ type DoctorRecommendationCardProps = {
 type ResultsHeaderProps = {
 	includeBackLink?: boolean;
 	initialSymptoms: string;
+	activeFilters?: SearchFilters;
+	onRefineFilters?: () => void;
 };
 
 type ResultsSearchSummaryProps = {
 	symptoms: string;
 };
 
+type ResultsActiveFiltersProps = {
+	filters: SearchFilters;
+	onRefine: () => void;
+};
+
+type ResultsRefineFiltersProps = {
+	location: string;
+	onlyAcceptingNewPatients: boolean;
+	onLocationChange: (value: string) => void;
+	onOnlyAcceptingChange: (value: boolean) => void;
+	onApply: () => void;
+	onCancel: () => void;
+	isRefining: boolean;
+};
+
 type ResultsPageProps = {
 	initialSymptoms: string;
+	initialFilters?: SearchFilters;
 	searchDoctorsImpl?: typeof searchDoctors;
 	includeBackLink?: boolean;
 };
@@ -79,11 +117,18 @@ export function normalizeSymptoms(symptoms: string) {
 	return symptoms.trim();
 }
 
-export function getResultsNavigation(symptoms: string) {
+export function getResultsNavigation(
+	symptoms: string,
+	filters?: SearchFilters,
+) {
 	return {
 		to: "/results" as const,
 		search: {
 			symptoms: normalizeSymptoms(symptoms),
+			...(filters?.location && { location: filters.location }),
+			...(filters?.onlyAcceptingNewPatients && {
+				onlyAcceptingNewPatients: "true",
+			}),
 		},
 	};
 }
@@ -96,7 +141,11 @@ export function getNextRecommendationLabel(hasNextDoctor: boolean) {
 
 export async function searchDoctors(
 	symptoms: string,
-	{ apiBaseUrl = API_BASE_URL, fetchImpl = fetch }: SearchDoctorsOptions = {},
+	{
+		apiBaseUrl = API_BASE_URL,
+		fetchImpl = fetch,
+		filters,
+	}: SearchDoctorsOptions = {},
 ): Promise<Doctor[]> {
 	const trimmedSymptoms = normalizeSymptoms(symptoms);
 	if (!trimmedSymptoms) {
@@ -105,14 +154,18 @@ export async function searchDoctors(
 		);
 	}
 
+	const body: Record<string, unknown> = { symptoms: trimmedSymptoms };
+	if (filters) {
+		if (filters.location) body.location = filters.location;
+		if (filters.onlyAcceptingNewPatients) body.onlyAcceptingNewPatients = true;
+	}
+
 	const response = await fetchImpl(getDoctorSearchUrl(apiBaseUrl), {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
 		},
-		body: JSON.stringify({
-			symptoms: trimmedSymptoms,
-		}),
+		body: JSON.stringify(body),
 	});
 
 	const payload = (await response.json()) as
@@ -194,12 +247,61 @@ export function SearchForm({
 	);
 }
 
+export function SearchFiltersForm({
+	location,
+	onlyAcceptingNewPatients,
+	onLocationChange,
+	onOnlyAcceptingChange,
+}: SearchFiltersFormProps) {
+	return (
+		<fieldset className="search-filters" aria-labelledby="filter-heading">
+			<legend id="filter-heading" className="filter-heading">
+				Filter by your preferences
+			</legend>
+			<div className="filter-fields">
+				<div className="filter-field">
+					<label htmlFor="filter-location">
+						Location (city, state, or ZIP)
+					</label>
+					<input
+						id="filter-location"
+						type="text"
+						value={location}
+						onChange={(e) => onLocationChange(e.target.value)}
+						placeholder="e.g. Pittsburgh, PA"
+						aria-describedby="filter-location-hint"
+					/>
+					<span id="filter-location-hint" className="filter-hint">
+						Show doctors near this area
+					</span>
+				</div>
+				<div className="filter-field filter-checkbox">
+					<input
+						id="filter-accepting"
+						type="checkbox"
+						checked={onlyAcceptingNewPatients}
+						onChange={(e) => onOnlyAcceptingChange(e.target.checked)}
+						aria-describedby="filter-accepting-hint"
+					/>
+					<label htmlFor="filter-accepting">
+						Only show doctors accepting new patients
+					</label>
+					<span id="filter-accepting-hint" className="filter-hint">
+						Filter by availability
+					</span>
+				</div>
+			</div>
+		</fieldset>
+	);
+}
+
 export function SearchHero({
 	symptoms,
 	onSymptomsChange,
 	onSubmit,
 	isLoading = false,
 	errorMessage,
+	filters,
 }: SearchHeroProps) {
 	return (
 		<section className="hero">
@@ -221,6 +323,15 @@ export function SearchHero({
 				onSubmit={onSubmit}
 				isLoading={isLoading}
 			/>
+
+			{filters ? (
+				<SearchFiltersForm
+					location={filters.location}
+					onlyAcceptingNewPatients={filters.onlyAcceptingNewPatients}
+					onLocationChange={filters.onLocationChange}
+					onOnlyAcceptingChange={filters.onOnlyAcceptingChange}
+				/>
+			) : null}
 
 			<div className="suggestion-list">
 				{SUGGESTED_SYMPTOMS.map((suggestion) => (
@@ -246,6 +357,9 @@ export function SearchHero({
 
 export function HomePage({ navigateToResults }: HomePageProps) {
 	const [symptoms, setSymptoms] = useState("");
+	const [location, setLocation] = useState("");
+	const [onlyAcceptingNewPatients, setOnlyAcceptingNewPatients] =
+		useState(false);
 	const [errorMessage, setErrorMessage] = useState("");
 
 	function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -260,7 +374,13 @@ export function HomePage({ navigateToResults }: HomePageProps) {
 		}
 
 		setErrorMessage("");
-		navigateToResults(trimmedSymptoms);
+		const filters: SearchFilters = {};
+		if (location.trim()) filters.location = location.trim();
+		if (onlyAcceptingNewPatients) filters.onlyAcceptingNewPatients = true;
+		navigateToResults(
+			trimmedSymptoms,
+			Object.keys(filters).length ? filters : undefined,
+		);
 	}
 
 	return (
@@ -270,6 +390,12 @@ export function HomePage({ navigateToResults }: HomePageProps) {
 				onSymptomsChange={setSymptoms}
 				onSubmit={handleSubmit}
 				errorMessage={errorMessage}
+				filters={{
+					location,
+					onlyAcceptingNewPatients,
+					onLocationChange: setLocation,
+					onOnlyAcceptingChange: setOnlyAcceptingNewPatients,
+				}}
 			/>
 		</SearchPageShell>
 	);
@@ -353,9 +479,101 @@ export function DoctorRecommendationCard({
 	);
 }
 
+export function ResultsActiveFilters({
+	filters,
+	onRefine,
+}: ResultsActiveFiltersProps) {
+	const labels: string[] = [];
+	if (filters.location) labels.push(filters.location);
+	if (filters.onlyAcceptingNewPatients) labels.push("Accepting new patients");
+
+	if (labels.length === 0) return null;
+
+	return (
+		<div className="results-active-filters">
+			<Filter aria-hidden="true" size={16} strokeWidth={2} />
+			<span className="results-active-filters-label">
+				Filtered by: {labels.join(" • ")}
+			</span>
+			<button
+				type="button"
+				className="results-refine-link"
+				onClick={onRefine}
+				aria-label="Refine location and availability filters"
+			>
+				Refine filters
+			</button>
+		</div>
+	);
+}
+
+export function ResultsRefineFilters({
+	location,
+	onlyAcceptingNewPatients,
+	onLocationChange,
+	onOnlyAcceptingChange,
+	onApply,
+	onCancel,
+	isRefining,
+}: ResultsRefineFiltersProps) {
+	if (!isRefining) return null;
+
+	return (
+		<div className="results-refine-filters">
+			<h3 id="refine-heading" className="refine-heading">
+				Refine your filters
+			</h3>
+			<div className="refine-fields">
+				<div className="filter-field">
+					<label htmlFor="refine-location">
+						Location (city, state, or ZIP)
+					</label>
+					<input
+						id="refine-location"
+						type="text"
+						value={location}
+						onChange={(e) => onLocationChange(e.target.value)}
+						placeholder="e.g. Pittsburgh, PA"
+					/>
+				</div>
+				<div className="filter-field filter-checkbox">
+					<input
+						id="refine-accepting"
+						type="checkbox"
+						checked={onlyAcceptingNewPatients}
+						onChange={(e) => onOnlyAcceptingChange(e.target.checked)}
+					/>
+					<label htmlFor="refine-accepting">
+						Only show doctors accepting new patients
+					</label>
+				</div>
+			</div>
+			<div className="refine-actions">
+				<button
+					type="button"
+					className="primary-action"
+					onClick={onApply}
+					aria-label="Apply refined filters"
+				>
+					Apply filters
+				</button>
+				<button
+					type="button"
+					className="secondary-action"
+					onClick={onCancel}
+					aria-label="Cancel refining filters"
+				>
+					Cancel
+				</button>
+			</div>
+		</div>
+	);
+}
+
 export function ResultsHeader({
 	includeBackLink = true,
 	initialSymptoms,
+	activeFilters,
 }: ResultsHeaderProps) {
 	return (
 		<header className="results-header">
@@ -368,6 +586,13 @@ export function ResultsHeader({
 				) : null}
 				<ResultsSearchSummary symptoms={initialSymptoms} />
 			</div>
+			{activeFilters &&
+			(activeFilters.location || activeFilters.onlyAcceptingNewPatients) ? (
+				<ResultsActiveFilters
+					filters={activeFilters}
+					onRefine={onRefineFilters ?? (() => {})}
+				/>
+			) : null}
 			<div className="results-copy">
 				<p className="results-kicker">Recommended doctors</p>
 				<h1 className="results-title">Recommended doctors</h1>
@@ -401,13 +626,27 @@ export function ResultsSearchSummary({ symptoms }: ResultsSearchSummaryProps) {
 
 export function ResultsPage({
 	initialSymptoms,
+	initialFilters,
 	searchDoctorsImpl = searchDoctors,
 	includeBackLink = false,
 }: ResultsPageProps) {
+	const navigate = useNavigate();
 	const [doctors, setDoctors] = useState<Doctor[]>([]);
 	const [activeDoctorIndex, setActiveDoctorIndex] = useState(0);
 	const [errorMessage, setErrorMessage] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
+	const [isRefining, setIsRefining] = useState(false);
+	const [refineLocation, setRefineLocation] = useState(
+		initialFilters?.location ?? "",
+	);
+	const [refineOnlyAccepting, setRefineOnlyAccepting] = useState(
+		initialFilters?.onlyAcceptingNewPatients ?? false,
+	);
+
+	useEffect(() => {
+		setRefineLocation(initialFilters?.location ?? "");
+		setRefineOnlyAccepting(initialFilters?.onlyAcceptingNewPatients ?? false);
+	}, [initialFilters]);
 
 	useEffect(() => {
 		let ignore = false;
@@ -417,7 +656,9 @@ export function ResultsPage({
 			setErrorMessage("");
 
 			try {
-				const matchedDoctors = await searchDoctorsImpl(initialSymptoms);
+				const matchedDoctors = await searchDoctorsImpl(initialSymptoms, {
+					filters: initialFilters,
+				});
 
 				if (ignore) {
 					return;
@@ -428,7 +669,7 @@ export function ResultsPage({
 
 				if (matchedDoctors.length === 0) {
 					setErrorMessage(
-						"No doctors matched those symptoms. Try adding more detail.",
+						"No doctors matched those symptoms. Try adding more detail or relaxing your filters.",
 					);
 				}
 			} catch (error) {
@@ -455,7 +696,7 @@ export function ResultsPage({
 		return () => {
 			ignore = true;
 		};
-	}, [initialSymptoms, searchDoctorsImpl]);
+	}, [initialSymptoms, initialFilters, searchDoctorsImpl]);
 
 	return (
 		<SearchPageShell>
@@ -467,6 +708,26 @@ export function ResultsPage({
 				<ResultsHeader
 					includeBackLink={includeBackLink}
 					initialSymptoms={initialSymptoms}
+					activeFilters={initialFilters}
+					onRefineFilters={
+						initialFilters ? () => setIsRefining(true) : undefined
+					}
+				/>
+
+				<ResultsRefineFilters
+					location={refineLocation}
+					onlyAcceptingNewPatients={refineOnlyAccepting}
+					onLocationChange={setRefineLocation}
+					onOnlyAcceptingChange={setRefineOnlyAccepting}
+					onApply={() => {
+						const filters: SearchFilters = {};
+						if (refineLocation.trim()) filters.location = refineLocation.trim();
+						if (refineOnlyAccepting) filters.onlyAcceptingNewPatients = true;
+						navigate(getResultsNavigation(initialSymptoms, filters));
+						setIsRefining(false);
+					}}
+					onCancel={() => setIsRefining(false)}
+					isRefining={isRefining}
 				/>
 
 				<div id="results-status" className="sr-only" aria-live="polite">

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -10,8 +10,8 @@ function HomeRoute() {
 
 	return (
 		<HomePage
-			navigateToResults={(symptoms) =>
-				void navigate(getResultsNavigation(symptoms))
+			navigateToResults={(symptoms, filters) =>
+				void navigate(getResultsNavigation(symptoms, filters))
 			}
 		/>
 	);

--- a/client/src/routes/results.tsx
+++ b/client/src/routes/results.tsx
@@ -1,19 +1,47 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { ResultsPage } from "../components/App";
+import { ResultsPage, type SearchFilters } from "../components/App";
 
 type ResultsSearch = {
 	symptoms: string;
+	location?: string;
+	onlyAcceptingNewPatients?: string;
 };
 
 export const Route = createFileRoute("/results")({
 	validateSearch: (search: Record<string, unknown>): ResultsSearch => ({
 		symptoms: typeof search.symptoms === "string" ? search.symptoms : "",
+		location:
+			typeof search.location === "string" && search.location.trim()
+				? search.location.trim()
+				: undefined,
+		onlyAcceptingNewPatients:
+			search.onlyAcceptingNewPatients === "true" ? "true" : undefined,
 	}),
 	component: ResultsRoutePage,
 });
 
 function ResultsRoutePage() {
-	const { symptoms: initialSymptoms } = Route.useSearch();
+	const {
+		symptoms: initialSymptoms,
+		location,
+		onlyAcceptingNewPatients,
+	} = Route.useSearch();
 
-	return <ResultsPage initialSymptoms={initialSymptoms} includeBackLink />;
+	const initialFilters: SearchFilters | undefined =
+		location || onlyAcceptingNewPatients
+			? {
+					...(location && { location }),
+					...(onlyAcceptingNewPatients === "true" && {
+						onlyAcceptingNewPatients: true,
+					}),
+				}
+			: undefined;
+
+	return (
+		<ResultsPage
+			initialSymptoms={initialSymptoms}
+			initialFilters={initialFilters}
+			includeBackLink
+		/>
+	);
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -316,6 +316,56 @@ a {
 	background: rgba(37, 54, 110, 0.62);
 }
 
+.search-filters {
+	margin-top: 1.75rem;
+	padding: 1.25rem 1.5rem;
+	border: 1px solid var(--line);
+	border-radius: 1.5rem;
+	background: rgba(12, 22, 52, 0.5);
+}
+
+.filter-heading {
+	margin: 0 0 1rem;
+	font-size: 0.95rem;
+	font-weight: 500;
+	color: var(--text-soft);
+}
+
+.filter-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.filter-field input[type="text"] {
+	width: 100%;
+	padding: 0.65rem 1rem;
+	border: 1px solid var(--line);
+	border-radius: 0.75rem;
+	background: rgba(15, 25, 56, 0.7);
+	color: var(--text);
+	font-size: 1rem;
+}
+
+.filter-field.filter-checkbox {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.filter-field.filter-checkbox input {
+	width: 1.25rem;
+	height: 1.25rem;
+	accent-color: var(--teal);
+}
+
+.filter-hint {
+	display: block;
+	margin-top: 0.35rem;
+	font-size: 0.85rem;
+	color: var(--text-muted);
+}
+
 .feedback-message {
 	width: min(48rem, 100%);
 	margin: 1.35rem auto 0;
@@ -349,6 +399,65 @@ a {
 	align-items: center;
 	gap: 1rem;
 	width: 100%;
+}
+
+.results-active-filters {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem 1rem;
+	padding: 0.65rem 1rem;
+	border-radius: 0.75rem;
+	background: rgba(32, 216, 255, 0.08);
+	border: 1px solid rgba(32, 216, 255, 0.2);
+}
+
+.results-active-filters-label {
+	font-size: 0.9rem;
+	color: var(--text-soft);
+}
+
+.results-refine-link {
+	padding: 0.35rem 0.75rem;
+	border: 0;
+	border-radius: 999px;
+	background: rgba(76, 141, 255, 0.25);
+	color: #a9dfff;
+	font-size: 0.85rem;
+	cursor: pointer;
+	transition: background 180ms ease;
+}
+
+.results-refine-link:hover,
+.results-refine-link:focus-visible {
+	background: rgba(76, 141, 255, 0.4);
+}
+
+.results-refine-filters {
+	margin-top: 1.25rem;
+	padding: 1.25rem 1.5rem;
+	border: 1px solid var(--line);
+	border-radius: 1.5rem;
+	background: rgba(12, 22, 52, 0.5);
+}
+
+.refine-heading {
+	margin: 0 0 1rem;
+	font-size: 1rem;
+	font-weight: 500;
+	color: var(--text-soft);
+}
+
+.refine-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	margin-bottom: 1rem;
+}
+
+.refine-actions {
+	display: flex;
+	gap: 0.75rem;
 }
 
 .back-link {

--- a/client/src/tests/index.test.tsx
+++ b/client/src/tests/index.test.tsx
@@ -8,7 +8,9 @@ import {
 	getNextRecommendationLabel,
 	getResultsNavigation,
 	normalizeSymptoms,
+	ResultsActiveFilters,
 	ResultsHeader,
+	SearchFiltersForm,
 	SearchHero,
 	SearchPageShell,
 	SUGGESTED_SYMPTOMS,
@@ -106,6 +108,49 @@ describe("frontend page flow", () => {
 		});
 	});
 
+	test("getResultsNavigation includes filter params when provided", () => {
+		expect(
+			getResultsNavigation("migraines", {
+				location: "Pittsburgh",
+				onlyAcceptingNewPatients: true,
+			}),
+		).toEqual({
+			to: "/results",
+			search: {
+				symptoms: "migraines",
+				location: "Pittsburgh",
+				onlyAcceptingNewPatients: "true",
+			},
+		});
+	});
+
+	test("searchDoctors sends filter params in the request body when provided", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ doctors: [] }),
+		});
+
+		await searchDoctors("headaches", {
+			apiBaseUrl: "http://localhost:3000",
+			fetchImpl: fetchMock as typeof fetch,
+			filters: {
+				location: "Pittsburgh",
+				onlyAcceptingNewPatients: true,
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://localhost:3000/doctors/search",
+			expect.objectContaining({
+				body: JSON.stringify({
+					symptoms: "headaches",
+					location: "Pittsburgh",
+					onlyAcceptingNewPatients: true,
+				}),
+			}),
+		);
+	});
+
 	test("renders the landing hero with the responsive helper copy hook", () => {
 		render(
 			<SearchHero symptoms="" onSymptomsChange={vi.fn()} onSubmit={vi.fn()} />,
@@ -169,6 +214,50 @@ describe("frontend page flow", () => {
 		).toBeTruthy();
 		expect(screen.getByText("persistent cough")).toBeTruthy();
 		expect(document.querySelector(".results-header-top")).toBeTruthy();
+	});
+
+	test("renders filter form with location and availability options", () => {
+		render(
+			<SearchFiltersForm
+				location="Pittsburgh"
+				onlyAcceptingNewPatients={true}
+				onLocationChange={vi.fn()}
+				onOnlyAcceptingChange={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("group", { name: /Filter by your preferences/ }),
+		).toBeTruthy();
+		expect(
+			screen.getByLabelText(/Location \(city, state, or ZIP\)/),
+		).toBeTruthy();
+		expect(
+			screen.getByLabelText(/Only show doctors accepting new patients/),
+		).toBeTruthy();
+	});
+
+	test("renders active filters when location and availability are applied", () => {
+		const onRefine = vi.fn();
+		render(
+			<ResultsActiveFilters
+				filters={{
+					location: "Pittsburgh, PA",
+					onlyAcceptingNewPatients: true,
+				}}
+				onRefine={onRefine}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/Filtered by: Pittsburgh, PA • Accepting new patients/),
+		).toBeTruthy();
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: /Refine location and availability filters/,
+			}),
+		);
+		expect(onRefine).toHaveBeenCalledTimes(1);
 	});
 
 	test("renders the doctor card header tag and actions with responsive hook classes", () => {


### PR DESCRIPTION
## User Story
As a patient looking for something specific, I want to filter my recommendations by my location and availability, so that I can only see doctors tailored to my preferences.

## Changes

### API
- Added `location` and `onlyAcceptingNewPatients` query parameters to `POST /doctors/search`
- Search service filters by `primary_location` (ILIKE) and `accepting_new_patients` when specified

### Client
- **Home page**: New filter form with location (city, state, or ZIP) and "Only show doctors accepting new patients" checkbox
- **Results page**: Displays active filters (e.g., "Filtered by: Pittsburgh, PA • Accepting new patients")
- **Refine filters**: Button to adjust location and availability filters without returning to home

### Tests
- API: Filter parameters passed to search service
- Client: `getResultsNavigation`, `searchDoctors` with filters, `SearchFiltersForm`, `ResultsActiveFilters`

Made with [Cursor](https://cursor.com)

resolves #7 