### PR TITLE
fix: botIds format in workflow file

### DIFF
--- a/.github/workflows/01-implement-story.yml
+++ b/.github/workflows/01-implement-story.yml
@@ -136,7 +136,7 @@ jobs:
                 }
               }' \
             -f issueId="${ISSUE_NODE_ID}" \
-            -f botIds="[\"${BOT_ID}\"]" \
+            -F botIds[]="${BOT_ID}" \
             -f instructions="${INSTRUCTIONS}"
 
           echo "Copilot assigned to issue #${ISSUE_NUM}. It will open a PR when done."


### PR DESCRIPTION
The initial github workflow that got merged in did not use the correct syntax to pass in an array to the github cli